### PR TITLE
fix(rbac): add lease permissions for leader election

### DIFF
--- a/chart/templates/_values-rbac.tpl
+++ b/chart/templates/_values-rbac.tpl
@@ -32,6 +32,18 @@ rbac:
             - list
             - watch
         - apiGroups:
+            - coordination.k8s.io
+          resources:
+            - leases
+          verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        - apiGroups:
             - nextdns.io
           resources:
             - nextdnsallowlists

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -25,6 +25,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - nextdns.io
   resources:
   - nextdnsallowlists

--- a/internal/controller/nextdnsprofile_controller.go
+++ b/internal/controller/nextdnsprofile_controller.go
@@ -63,6 +63,7 @@ type NextDNSProfileReconciler struct {
 // +kubebuilder:rbac:groups=nextdns.io,resources=nextdnstldlists,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop
 func (r *NextDNSProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
## Summary
- Adds RBAC permissions for `leases` in `coordination.k8s.io` API group
- Required for leader election to function when enabled via `--leader-elect` flag
- Fixes operator crash loop when deployed with leader election

## Test plan
- [ ] Deploy operator with `--leader-elect=true`
- [ ] Verify no "forbidden" errors for leases in logs
- [ ] Confirm leader election works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)