### PR TITLE
fix(rbac): use correct API group for list controllers

### DIFF
--- a/chart/templates/_values-rbac.tpl
+++ b/chart/templates/_values-rbac.tpl
@@ -48,42 +48,7 @@ rbac:
           resources:
             - nextdnsallowlists
             - nextdnsdenylists
-            - nextdnstldlists
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - nextdns.io
-          resources:
             - nextdnsprofiles
-          verbs:
-            - create
-            - delete
-            - get
-            - list
-            - patch
-            - update
-            - watch
-        - apiGroups:
-            - nextdns.io
-          resources:
-            - nextdnsprofiles/finalizers
-          verbs:
-            - update
-        - apiGroups:
-            - nextdns.io
-          resources:
-            - nextdnsprofiles/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - nextdns.jacaudi.com
-          resources:
-            - nextdnsallowlists
-            - nextdnsdenylists
             - nextdnstldlists
           verbs:
             - create
@@ -94,18 +59,20 @@ rbac:
             - update
             - watch
         - apiGroups:
-            - nextdns.jacaudi.com
+            - nextdns.io
           resources:
             - nextdnsallowlists/finalizers
             - nextdnsdenylists/finalizers
+            - nextdnsprofiles/finalizers
             - nextdnstldlists/finalizers
           verbs:
             - update
         - apiGroups:
-            - nextdns.jacaudi.com
+            - nextdns.io
           resources:
             - nextdnsallowlists/status
             - nextdnsdenylists/status
+            - nextdnsprofiles/status
             - nextdnstldlists/status
           verbs:
             - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -41,42 +41,7 @@ rules:
   resources:
   - nextdnsallowlists
   - nextdnsdenylists
-  - nextdnstldlists
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - nextdns.io
-  resources:
   - nextdnsprofiles
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - nextdns.io
-  resources:
-  - nextdnsprofiles/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - nextdns.io
-  resources:
-  - nextdnsprofiles/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - nextdns.jacaudi.com
-  resources:
-  - nextdnsallowlists
-  - nextdnsdenylists
   - nextdnstldlists
   verbs:
   - create
@@ -87,18 +52,20 @@ rules:
   - update
   - watch
 - apiGroups:
-  - nextdns.jacaudi.com
+  - nextdns.io
   resources:
   - nextdnsallowlists/finalizers
   - nextdnsdenylists/finalizers
+  - nextdnsprofiles/finalizers
   - nextdnstldlists/finalizers
   verbs:
   - update
 - apiGroups:
-  - nextdns.jacaudi.com
+  - nextdns.io
   resources:
   - nextdnsallowlists/status
   - nextdnsdenylists/status
+  - nextdnsprofiles/status
   - nextdnstldlists/status
   verbs:
   - get

--- a/internal/controller/nextdnsallowlist_controller.go
+++ b/internal/controller/nextdnsallowlist_controller.go
@@ -32,9 +32,9 @@ type NextDNSAllowlistReconciler struct {
 	SyncPeriod time.Duration
 }
 
-// +kubebuilder:rbac:groups=nextdns.jacaudi.com,resources=nextdnsallowlists,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=nextdns.jacaudi.com,resources=nextdnsallowlists/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=nextdns.jacaudi.com,resources=nextdnsallowlists/finalizers,verbs=update
+// +kubebuilder:rbac:groups=nextdns.io,resources=nextdnsallowlists,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=nextdns.io,resources=nextdnsallowlists/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=nextdns.io,resources=nextdnsallowlists/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controller/nextdnsdenylist_controller.go
+++ b/internal/controller/nextdnsdenylist_controller.go
@@ -31,9 +31,9 @@ type NextDNSDenylistReconciler struct {
 	SyncPeriod time.Duration
 }
 
-// +kubebuilder:rbac:groups=nextdns.jacaudi.com,resources=nextdnsdenylists,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=nextdns.jacaudi.com,resources=nextdnsdenylists/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=nextdns.jacaudi.com,resources=nextdnsdenylists/finalizers,verbs=update
+// +kubebuilder:rbac:groups=nextdns.io,resources=nextdnsdenylists,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=nextdns.io,resources=nextdnsdenylists/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=nextdns.io,resources=nextdnsdenylists/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controller/nextdnstldlist_controller.go
+++ b/internal/controller/nextdnstldlist_controller.go
@@ -31,9 +31,9 @@ type NextDNSTLDListReconciler struct {
 	SyncPeriod time.Duration
 }
 
-// +kubebuilder:rbac:groups=nextdns.jacaudi.com,resources=nextdnstldlists,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=nextdns.jacaudi.com,resources=nextdnstldlists/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=nextdns.jacaudi.com,resources=nextdnstldlists/finalizers,verbs=update
+// +kubebuilder:rbac:groups=nextdns.io,resources=nextdnstldlists,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=nextdns.io,resources=nextdnstldlists/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=nextdns.io,resources=nextdnstldlists/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
## Summary
- Fixes RBAC markers in allowlist, denylist, and tldlist controllers
- Changes API group from `nextdns.jacaudi.com` to `nextdns.io` to match CRDs
- Consolidates all RBAC rules under the correct `nextdns.io` group

This fixes "Failed to update status" errors for the list controllers.

## Test plan
- [ ] Deploy operator and create NextDNSDenylist, NextDNSAllowlist, NextDNSTLDList resources
- [ ] Verify no "Failed to update status" errors in logs
- [ ] Confirm status updates work for all list resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)