### PR TITLE
fix(rbac): use plural resource name for NextDNSCoreDNS

### DIFF
--- a/chart/templates/_values-rbac.tpl
+++ b/chart/templates/_values-rbac.tpl
@@ -61,7 +61,7 @@ rbac:
             - nextdns.io
           resources:
             - nextdnsallowlists
-            - nextdnscoredns
+            - nextdnscorednses
             - nextdnsdenylists
             - nextdnsprofiles
             - nextdnstldlists
@@ -77,7 +77,7 @@ rbac:
             - nextdns.io
           resources:
             - nextdnsallowlists/finalizers
-            - nextdnscoredns/finalizers
+            - nextdnscorednses/finalizers
             - nextdnsdenylists/finalizers
             - nextdnsprofiles/finalizers
             - nextdnstldlists/finalizers
@@ -87,7 +87,7 @@ rbac:
             - nextdns.io
           resources:
             - nextdnsallowlists/status
-            - nextdnscoredns/status
+            - nextdnscorednses/status
             - nextdnsdenylists/status
             - nextdnsprofiles/status
             - nextdnstldlists/status

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -54,7 +54,7 @@ rules:
   - nextdns.io
   resources:
   - nextdnsallowlists
-  - nextdnscoredns
+  - nextdnscorednses
   - nextdnsdenylists
   - nextdnsprofiles
   - nextdnstldlists
@@ -70,7 +70,7 @@ rules:
   - nextdns.io
   resources:
   - nextdnsallowlists/finalizers
-  - nextdnscoredns/finalizers
+  - nextdnscorednses/finalizers
   - nextdnsdenylists/finalizers
   - nextdnsprofiles/finalizers
   - nextdnstldlists/finalizers
@@ -80,7 +80,7 @@ rules:
   - nextdns.io
   resources:
   - nextdnsallowlists/status
-  - nextdnscoredns/status
+  - nextdnscorednses/status
   - nextdnsdenylists/status
   - nextdnsprofiles/status
   - nextdnstldlists/status

--- a/internal/controller/nextdnscoredns_controller.go
+++ b/internal/controller/nextdnscoredns_controller.go
@@ -47,9 +47,9 @@ type NextDNSCoreDNSReconciler struct {
 	SyncPeriod time.Duration
 }
 
-// +kubebuilder:rbac:groups=nextdns.io,resources=nextdnscoredns,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=nextdns.io,resources=nextdnscoredns/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=nextdns.io,resources=nextdnscoredns/finalizers,verbs=update
+// +kubebuilder:rbac:groups=nextdns.io,resources=nextdnscorednses,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=nextdns.io,resources=nextdnscorednses/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=nextdns.io,resources=nextdnscorednses/finalizers,verbs=update
 // +kubebuilder:rbac:groups=nextdns.io,resources=nextdnsprofiles,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
## Summary

Fixes #34

The RBAC ClusterRole was using `nextdnscoredns` (singular) but the CRD resource name is `nextdnscorednses` (plural), causing permission errors when the operator tries to watch/list NextDNSCoreDNS resources.

## Error Fixed

```
ERROR controller-runtime.cache.UnhandledError Failed to watch
{"type": "*v1alpha1.NextDNSCoreDNS", "error": "failed to list *v1alpha1.NextDNSCoreDNS: nextdnscorednses.nextdns.io is forbidden: User \"system:serviceaccount:platform-system:nextdns-operator\" cannot list resource \"nextdnscorednses\" in API group \"nextdns.io\" at the cluster scope"}
```

## Changes

- Updated kubebuilder RBAC markers in controller to use `nextdnscorednses` (plural)
- Regenerated `config/rbac/role.yaml`
- Regenerated `chart/templates/_values-rbac.tpl`

## Test Plan

- [x] Unit tests pass
- [ ] Deploy and verify operator can watch NextDNSCoreDNS resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)