### PR TITLE
fix: clamp retention values to valid CRD enum in observe mode

### DIFF
--- a/internal/controller/nextdnsprofile_controller.go
+++ b/internal/controller/nextdnsprofile_controller.go
@@ -1176,18 +1176,26 @@ func boolPtr(b bool) *bool {
 }
 
 // formatRetentionString converts a retention value in days to the spec string format
+// formatRetentionString converts a retention value in days to the nearest valid
+// CRD enum value. The NextDNS API may return unexpected values (e.g., 31536000
+// for "unlimited"), so we clamp to the nearest supported retention period.
+// Valid values: 1h, 6h, 1d, 7d, 30d, 90d, 1y, 2y
 func formatRetentionString(days int) string {
-	switch days {
-	case 0:
-		// Sub-day retentions (1h, 6h) round to 0 days in the API.
-		// Map to 1h as the most conservative sub-day value.
+	switch {
+	case days <= 0:
 		return "1h"
-	case 365:
+	case days == 1:
+		return "1d"
+	case days <= 7:
+		return "7d"
+	case days <= 30:
+		return "30d"
+	case days <= 90:
+		return "90d"
+	case days <= 365:
 		return "1y"
-	case 730:
-		return "2y"
 	default:
-		return fmt.Sprintf("%dd", days)
+		return "2y"
 	}
 }
 

--- a/internal/controller/nextdnsprofile_controller_test.go
+++ b/internal/controller/nextdnsprofile_controller_test.go
@@ -2988,6 +2988,15 @@ func TestFormatRetentionString(t *testing.T) {
 		{name: "90 days", days: 90, expected: "90d"},
 		{name: "365 days is 1y", days: 365, expected: "1y"},
 		{name: "730 days is 2y", days: 730, expected: "2y"},
+		// Out-of-range values clamp UP to next valid enum (safer: retains more data)
+		{name: "negative clamps to 1h", days: -1, expected: "1h"},
+		{name: "2 days rounds up to 7d", days: 2, expected: "7d"},
+		{name: "15 days rounds up to 30d", days: 15, expected: "30d"},
+		{name: "60 days rounds up to 90d", days: 60, expected: "90d"},
+		{name: "180 days rounds up to 1y", days: 180, expected: "1y"},
+		{name: "500 days rounds up to 2y", days: 500, expected: "2y"},
+		{name: "1000 days clamps to 2y", days: 1000, expected: "2y"},
+		{name: "31536000 days (API bug) clamps to 2y", days: 31536000, expected: "2y"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Fixes observe mode failing with `Unsupported value: "31536000d"` when the NextDNS API returns an unexpected retention value.

Closes #72

### Root cause

`formatRetentionString` produced arbitrary strings like `"31536000d"` for out-of-range API values. The CRD enum on `suggestedSpec.settings.logs.retention` rejected these, causing the entire status update to fail and observe mode to loop indefinitely.

### Fix

Changed `formatRetentionString` from a switch on exact values to range-based clamping that always produces a valid enum value. Out-of-range values round UP to the next valid period (safer: retains more data).

| API days | Before | After |
|----------|--------|-------|
| 0 | `1h` | `1h` |
| 2 | `2d` (invalid) | `7d` |
| 31536000 | `31536000d` (invalid) | `2y` |
| -1 | `-1d` (invalid) | `1h` |

## Test plan

- [x] 15 test cases covering all valid values + 8 out-of-range edge cases
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)