### PR TITLE
fix: include refactor and chore(deps) commits in release notes

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,16 +6,23 @@
       "@semantic-release/commit-analyzer",
       {
         "releaseRules": [
-          {
-            "breaking": true,
-            "release": "minor"
-          }
+          { "breaking": true, "release": "minor" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "chore", "scope": "deps", "release": "patch" }
         ]
       }
     ],
     [
       "@semantic-release/release-notes-generator",
       {
+        "presetConfig": {
+          "types": [
+            { "type": "feat", "section": "Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+            { "type": "refactor", "section": "Code Refactoring" },
+            { "type": "chore", "scope": "deps", "section": "Dependencies" }
+          ]
+        },
         "writerOpts": {
           "headerPartial": "## {{#if @root.linkCompare~}}[{{version}}]({{@root.host}}/{{@root.owner}}/{{@root.repository}}/compare/{{previousTag}}...{{currentTag}}){{~else}}{{~version}}{{~/if}} ({{date}})"
         }


### PR DESCRIPTION
## Summary

- Add release rules for `refactor` (patch) and `chore(deps)` (patch) commits to trigger releases
- Add `presetConfig.types` to release-notes-generator for "Code Refactoring" and "Dependencies" changelog sections
- Dependency updates and refactors now appear in release notes instead of being invisible

Closes #119

## Test Plan

- [ ] Verify next release includes all commit types in changelog
- [ ] Verify `chore(deps)` commits appear under "Dependencies" section
- [ ] Verify `refactor` commits appear under "Code Refactoring" section
- [ ] Verify `chore` without `deps` scope does NOT trigger a release

🤖 Generated with [Claude Code](https://claude.com/claude-code)