### PR TITLE
ci: adopt cloudflare-operator workflow structure + version stamping

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,6 +1,7 @@
 ---
 # CI/CD Pipeline for NextDNS Operator
-# Runs linting, testing, container builds, and Helm chart publishing
+# Runs linting, testing, container builds, and Helm chart publishing.
+# Releases are produced automatically on every push to main (no manual gate).
 name: CI/CD
 
 "on":
@@ -8,10 +9,12 @@ name: CI/CD
     branches: [main]
   workflow_dispatch:
 
-# Only allow one release at a time - queue subsequent runs
+# Only allow one release at a time. Do not cancel an in-flight release —
+# a half-published release (image without chart, or vice versa) is worse
+# than waiting.
 concurrency:
   group: release
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -44,22 +47,24 @@ jobs:
       coverage-threshold: 70
       test-packages: './internal/controller/... ./internal/nextdns/... ./internal/coredns/...'
 
-  # Manual approval gate - pauses after lint/test until a reviewer approves.
-  # Configure the "release" environment in Settings > Environments with
-  # required reviewers.
-  approve:
-    name: Approve Release
-    needs: [lint, test]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  # Build metadata for version stamping (short commit + ISO build date).
+  meta:
+    name: Build Metadata
     runs-on: ubuntu-latest
-    environment: release
+    outputs:
+      commit: ${{ steps.m.outputs.commit }}
+      date: ${{ steps.m.outputs.date }}
     steps:
-      - name: Release approved
-        run: echo "Release approved, proceeding with semantic release..."
+      - id: m
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          echo "commit=${SHA:0:7}" >> "${GITHUB_OUTPUT}"
+          echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${GITHUB_OUTPUT}"
 
   # Create semantic version and GitHub release (main branch only)
   release:
-    needs: [approve]
+    needs: [lint, test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: jacaudi/github-actions/.github/workflows/component-semantic-release.yml@v0.20.3
     permissions:
@@ -68,14 +73,14 @@ jobs:
       pull-requests: write
     with:
       use-github-app: true
-      extra-plugins: '@semantic-release/changelog @semantic-release/git @semantic-release/exec'
+      extra-plugins: '@semantic-release/changelog @semantic-release/git @semantic-release/exec conventional-changelog-conventionalcommits'
     secrets:
       app-id: ${{ secrets.APP_ID }}
       app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
   # Build multi-arch container images
   container:
-    needs: [release]
+    needs: [release, meta]
     if: needs.release.outputs.new-release-published == 'true'
     uses: jacaudi/github-actions/.github/workflows/component-container-build.yml@v0.20.3
     permissions:
@@ -85,13 +90,19 @@ jobs:
       image-name: ${{ github.repository }}
       platforms: 'linux/amd64,linux/arm64'
       version: ${{ needs.release.outputs.new-release-version }}
+      build-args: |
+        VERSION=${{ needs.release.outputs.new-release-version-v }}
+        COMMIT=${{ needs.meta.outputs.commit }}
+        DATE=${{ needs.meta.outputs.date }}
       tags: |
         ghcr.io/${{ github.repository }}:${{ needs.release.outputs.new-release-version-v }}
         ghcr.io/${{ github.repository }}:latest
 
-  # Publish Helm chart to OCI registry
+  # Publish Helm chart to OCI registry (runs after the container build so the
+  # chart's appVersion always points at an image tag that already exists in
+  # the registry)
   helm:
-    needs: [release]
+    needs: [release, container]
     if: needs.release.outputs.new-release-published == 'true'
     uses: jacaudi/github-actions/.github/workflows/component-helm-publish.yml@v0.20.3
     permissions:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,94 @@
+---
+# On-demand Test Build
+# Manually-triggered build of a TEST (alpha) operator image + Helm chart
+# from any branch EXCEPT main. Nothing runs automatically — use the
+# "Run workflow" button. Releases are still owned exclusively by ci-cd.yml
+# on pushes to main.
+name: Test Build
+
+"on":
+  workflow_dispatch:
+
+# A newer manual run on the same ref supersedes an in-flight one.
+concurrency:
+  group: test-build-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  # Refuse to run on main, and compute the test version identifiers.
+  guard:
+    name: Guard + Versioning
+    runs-on: ubuntu-latest
+    outputs:
+      slug: ${{ steps.vars.outputs.slug }}
+      sha7: ${{ steps.vars.outputs.sha7 }}
+      date: ${{ steps.vars.outputs.date }}
+    steps:
+      - name: Refuse main
+        if: github.ref_name == 'main'
+        run: |
+          echo "::error::Test Build must not be run on 'main'. \
+          Releases are produced by ci-cd.yml. Re-run this from a feature branch."
+          exit 1
+
+      - name: Compute test version
+        id: vars
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+        run: |
+          # Sanitize the branch name into a single token that is valid as
+          # both a Docker tag fragment and a SemVer prerelease identifier:
+          # anything outside [a-z0-9-] becomes '-', repeats collapse, ends trim.
+          slug="$(echo "${REF_NAME}" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -e 's/[^a-z0-9-]/-/g' -e 's/-\{2,\}/-/g' -e 's/^-//' -e 's/-$//')"
+          sha7="${SHA:0:7}"
+          date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "slug=${slug}" >> "${GITHUB_OUTPUT}"
+          echo "sha7=${sha7}" >> "${GITHUB_OUTPUT}"
+          echo "date=${date}" >> "${GITHUB_OUTPUT}"
+          echo "Test build: slug='${slug}' sha7='${sha7}' date='${date}'" >> "${GITHUB_STEP_SUMMARY}"
+
+  # Multi-arch TEST image pushed to GHCR (parity with the release pipeline).
+  container:
+    needs: [guard]
+    uses: jacaudi/github-actions/.github/workflows/component-container-build.yml@v0.20.3
+    permissions:
+      contents: read
+      packages: write
+    with:
+      image-name: ${{ github.repository }}
+      platforms: 'linux/amd64,linux/arm64'
+      version: test-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.sha7 }}
+      build-args: |
+        VERSION=test-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.sha7 }}
+        COMMIT=${{ needs.guard.outputs.sha7 }}
+        DATE=${{ needs.guard.outputs.date }}
+      tags: |
+        ghcr.io/${{ github.repository }}:test-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.sha7 }}
+        ghcr.io/${{ github.repository }}:test-${{ needs.guard.outputs.slug }}
+
+  # TEST chart published to the same OCI path as releases, but the
+  # 0.0.0-alpha.<slug>.<sha7> prerelease version and test-* appVersion make
+  # it unmistakably a non-release artifact. Its appVersion drives the
+  # chart's image tag (values.yaml image.tag is empty -> .Chart.AppVersion),
+  # so it always references the test image built just above.
+  helm:
+    needs: [guard, container]
+    uses: jacaudi/github-actions/.github/workflows/component-helm-publish.yml@v0.20.3
+    permissions:
+      contents: read
+      packages: write
+    with:
+      chart-name: nextdns-operator
+      chart-path: chart
+      repository: ${{ github.repository_owner }}/charts
+      registry: ghcr.io
+      registry-username: ${{ github.repository_owner }}
+      version: 0.0.0-alpha.${{ needs.guard.outputs.slug }}.${{ needs.guard.outputs.sha7 }}
+      app-version: test-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.sha7 }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,12 @@
 FROM golang:1.26.3 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+# Version stamping — mirrors the Taskfile build LDFLAGS so the binary's
+# --version reports real values. Defaults keep plain `docker build`
+# working; CI passes the real values via --build-arg.
+ARG VERSION=dev
+ARG COMMIT=none
+ARG DATE=unknown
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -21,7 +27,9 @@ COPY internal/ internal/
 # having that, during the docker BUILDX://github.com/docker/buildx#--teleportation-and-multi-architecture-images
 # having it can be GOOS is picked up from TARGETOS, GOARCH being the
 # having platforms flags.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -trimpath \
+    -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" \
+    -o manager cmd/main.go
 
 # Use scratch as minimal base image with CA certificates for HTTPS
 FROM scratch

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,6 +6,16 @@ vars:
   LOCALBIN: '{{.ROOT_DIR}}/bin'
   CONTROLLER_TOOLS_VERSION: v0.21.0
   CONTROLLER_GEN: '{{.LOCALBIN}}/controller-gen'
+  # Version stamping — injected into the binary via -ldflags so `manager
+  # --version` reports real values. CI mirrors these via the Dockerfile
+  # build-args (VERSION/COMMIT/DATE).
+  version:
+    sh: git describe --tags --always --dirty 2>/dev/null || echo dev
+  commit:
+    sh: git rev-parse --short HEAD 2>/dev/null || echo none
+  date:
+    sh: date -u +%Y-%m-%dT%H:%M:%SZ
+  ldflags: '-s -w -X main.version={{.version}} -X main.commit={{.commit}} -X main.date={{.date}}'
 
 tasks:
   default:
@@ -74,7 +84,7 @@ tasks:
     desc: Build the operator binary
     deps: [manifests, generate, fmt, vet]
     cmds:
-      - go build -o bin/manager cmd/main.go
+      - go build -ldflags '{{.ldflags}}' -o bin/manager cmd/main.go
 
   run:
     desc: Run the controller locally

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log/slog"
 	"os"
 	"strings"
@@ -31,6 +32,20 @@ var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 )
+
+// version, commit, date are injected via -ldflags at build time
+// (-X main.version=... etc.); the defaults apply for `go run` / plain
+// `go build`.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+// versionString is the single formatter for --version and the startup log.
+func versionString() string {
+	return fmt.Sprintf("nextdns-operator %s (commit %s, built %s)", version, commit, date)
+}
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -75,12 +90,22 @@ func main() {
 	flag.StringVar(&logFormat, "log-format", lookupEnvOrString("LOG_FORMAT", "json"),
 		"Log format (json, text). Can also be set via LOG_FORMAT environment variable.")
 
+	var showVersion bool
+	flag.BoolVar(&showVersion, "version", false, "Print build version and exit.")
+
 	flag.Parse()
+
+	// --version short-circuits before any setup so it works unconditionally.
+	if showVersion {
+		fmt.Println(versionString())
+		os.Exit(0)
+	}
 
 	slogLogger := setupLogger(logLevel, logFormat)
 	slog.SetDefault(slogLogger)
 	ctrl.SetLogger(logr.FromSlogHandler(slogLogger.Handler()))
 	klog.SetSlogLogger(slogLogger)
+	setupLog.Info("starting nextdns-operator", "version", version, "commit", commit, "date", date)
 
 	// Parse sync period
 	syncDuration, err := time.ParseDuration(syncPeriod)


### PR DESCRIPTION
Ports cloudflare-operator's CI workflow improvements to nextdns-operator, adapted to this repo's tooling (Taskfile, not Make) and preserving nextdns-specific checks.

## What changed

**Version stamping (new `feat`)**
- `cmd/main.go`: `version`/`commit`/`date` vars (ldflags-injected) + a `--version` flag + version in the startup log.
- `Dockerfile`: `VERSION`/`COMMIT`/`DATE` build-args → `-ldflags -X main.*` (defaults keep plain `docker build` working).
- `Taskfile.yml`: `build` stamps from git (`git describe`/`rev-parse`/date).

**ci-cd.yml**
- ❌ Removed the manual approval gate → **releases are now automatic on push to main**.
- Added a `meta` job; pass `VERSION/COMMIT/DATE` build-args to the container build.
- `helm` publish now runs after `container` (chart appVersion always references an image that exists).
- Added `conventional-changelog-conventionalcommits` to semantic-release.
- `concurrency.cancel-in-progress: false` (don't cancel an in-flight release).

**test-build.yml (new)**
- On-demand (`workflow_dispatch`) alpha image + chart build from non-main branches; refuses to run on main.

## Deliberately NOT ported
- **envtest job** — nextdns-operator has no envtest-based tests (all controller tests use the fake client), so the job would be hollow. Skipped per discussion.
- **Helm CRD/RBAC sync PR checks + PR container builds** — kept (cloudflare lacks them; they're nextdns essentials).
- **Coverage threshold (70) and the 3 test packages** — kept (cloudflare uses 40 / api+internal+cmd).

## ⚠️ Note on merging
Because the approval gate is removed, **merging this PR will auto-release** — the `feat:` commit will cut a minor version (≈ v0.20.0), build the version-stamped image, and publish the chart. That's the intended new flow; just be aware the first gate-less release fires on merge.

## Verification
- `--version` prints stamped values; defaults fall back to `dev/none/unknown`.
- `go build`, `go vet`, full `go test ./...` all pass.
- All three workflows validated with `actionlint` (clean) and YAML-parsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)